### PR TITLE
Figure captions to span properly on narrow images

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -9,7 +9,34 @@
     		jQuery(".navbar-toggler").toggleClass("opened");
     		jQuery(".navbar-collapse").toggleClass("show");
     		jQuery("#backdrop").toggleClass("show");
-    	})		
+    	})
+
+    	function imageCaption() {
+    		
+    		var figure = jQuery("figure");
+    		var main = jQuery("div#main.col-lg-8");
+    		var mainwidth = main.width();
+
+    		for (var i = 0; i < figure.length; i++) {
+    			var figchildren = figure[i].childNodes;
+    				for (var n = 0; n < figchildren.length; n++) {
+    					if(figchildren[n].nodeName == 'IMG') {
+    						var imgwidth = figchildren[n].width;
+    					}
+    					var ratio = mainwidth/imgwidth;
+    					if(figchildren[n].nodeName == 'FIGCAPTION' && ratio > 1.1) {
+    						var figwidth = mainwidth-imgwidth;
+    						figchildren[n].setAttribute("style","position:absolute;bottom:0;right:0;padding:0 1em");
+    						figchildren[n].style.width = figwidth + "px";
+    						console.log('Figwidth:', figwidth);
+    					}
+
+    				}
+
+    		}
+
+    	}
+    	imageCaption();
 	});
 	
 })(jQuery, this);


### PR DESCRIPTION
If image is taking less than 76% of a space we set new width and position for captions: on a right from an image.